### PR TITLE
PoP API improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,12 +3579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
-name = "constcat"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f272d0c4cf831b4fa80ee529c7707f76585986e910e1fbce1d7921970bc1a241"
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22169,7 +22163,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.8",
  "sp-crypto-hashing 0.1.0",
- "sp-crypto-pubkeycrypto-proc-macro",
  "sp-debug-derive 14.0.0",
  "sp-externalities 0.25.0",
  "sp-runtime-interface 24.0.0",
@@ -22412,15 +22405,6 @@ dependencies = [
  "quote 1.0.38",
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "sp-crypto-pubkeycrypto-proc-macro"
-version = "0.1.0"
-dependencies = [
- "quote 1.0.37",
- "sp-crypto-hashing 0.1.0",
- "syn 2.0.79",
 ]
 
 [[package]]
@@ -26198,9 +26182,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "w3f-bls"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3028804c8bbae2a97a15b71ffc0e308c4b01a520994aafa77d56e94e19024"
+checksum = "e6bfb937b3d12077654a9e43e32a4e9c20177dd9fea0f3aba673e7840bb54f32"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381 0.4.0",
@@ -26209,14 +26193,12 @@ dependencies = [
  "ark-serialize 0.4.2",
  "ark-serialize-derive 0.4.2",
  "arrayref",
- "constcat",
  "digest 0.10.7",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3 0.10.8",
- "thiserror 1.0.65",
  "zeroize",
 ]
 

--- a/substrate/primitives/application-crypto/src/bandersnatch.rs
+++ b/substrate/primitives/application-crypto/src/bandersnatch.rs
@@ -23,7 +23,7 @@ pub use sp_core::bandersnatch::*;
 
 use sp_core::{
 	crypto::CryptoType,
-	pop::{POP_CONTEXT_TAG, ProofOfPossessionVerifier},
+	pop::{NonAggregatable, ProofOfPossessionVerifier},
 	Pair as TraitPair,
 };
 
@@ -58,9 +58,8 @@ impl RuntimePublic for Public {
 	}
 
 	fn generate_pop(&mut self, key_type: KeyTypeId) -> Option<Self::Signature> {
-		let pub_key_as_bytes = self.to_raw_vec();
-		let pop_statement = [POP_CONTEXT_TAG, pub_key_as_bytes.as_slice()].concat();
-		sp_io::crypto::bandersnatch_sign(key_type, self, pop_statement.as_slice())
+		let pop_statement = Pair::pop_statement(self);
+		sp_io::crypto::bandersnatch_sign(key_type, self, &pop_statement)
 	}
 
 	fn verify_pop(&self, pop: &Self::Signature) -> bool {

--- a/substrate/primitives/application-crypto/src/ecdsa.rs
+++ b/substrate/primitives/application-crypto/src/ecdsa.rs
@@ -21,8 +21,8 @@ use crate::{KeyTypeId, RuntimePublic};
 
 use alloc::vec::Vec;
 
-use sp_core::pop::POP_CONTEXT_TAG;
 pub use sp_core::ecdsa::*;
+use sp_core::pop::NonAggregatable;
 
 mod app {
 	crate::app_crypto!(super, sp_core::testing::ECDSA);
@@ -50,14 +50,12 @@ impl RuntimePublic for Public {
 	}
 
 	fn generate_pop(&mut self, key_type: KeyTypeId) -> Option<Self::Signature> {
-		let pub_key_as_bytes = self.to_raw_vec();
-		let pop_statement = [POP_CONTEXT_TAG, pub_key_as_bytes.as_slice()].concat();
-		sp_io::crypto::ecdsa_sign(key_type, self, pop_statement.as_slice())
+		let pop_statement = Pair::pop_statement(self);
+		sp_io::crypto::ecdsa_sign(key_type, self, &pop_statement)
 	}
 
 	fn verify_pop(&self, pop: &Self::Signature) -> bool {
-		let pub_key_as_bytes = self.to_raw_vec();
-		let pop_statement = [POP_CONTEXT_TAG, pub_key_as_bytes.as_slice()].concat();
+		let pop_statement = Pair::pop_statement(self);
 		sp_io::crypto::ecdsa_verify(&pop, &pop_statement, &self)
 	}
 

--- a/substrate/primitives/application-crypto/src/ed25519.rs
+++ b/substrate/primitives/application-crypto/src/ed25519.rs
@@ -21,8 +21,8 @@ use crate::{KeyTypeId, RuntimePublic};
 
 use alloc::vec::Vec;
 
-use sp_core::pop::POP_CONTEXT_TAG;
 pub use sp_core::ed25519::*;
+use sp_core::pop::NonAggregatable;
 
 mod app {
 	crate::app_crypto!(super, sp_core::testing::ED25519);
@@ -50,14 +50,12 @@ impl RuntimePublic for Public {
 	}
 
 	fn generate_pop(&mut self, key_type: KeyTypeId) -> Option<Self::Signature> {
-		let pub_key_as_bytes = self.to_raw_vec();
-		let pop_statement = [POP_CONTEXT_TAG, pub_key_as_bytes.as_slice()].concat();
-		sp_io::crypto::ed25519_sign(key_type, self, pop_statement.as_slice())
+		let pop_statement = Pair::pop_statement(self);
+		sp_io::crypto::ed25519_sign(key_type, self, &pop_statement)
 	}
 
 	fn verify_pop(&self, pop: &Self::Signature) -> bool {
-		let pub_key_as_bytes = self.to_raw_vec();
-		let pop_statement = [POP_CONTEXT_TAG, pub_key_as_bytes.as_slice()].concat();
+		let pop_statement = Pair::pop_statement(self);
 		sp_io::crypto::ed25519_verify(&pop, &pop_statement, &self)
 	}
 

--- a/substrate/primitives/application-crypto/src/lib.rs
+++ b/substrate/primitives/application-crypto/src/lib.rs
@@ -24,15 +24,13 @@ extern crate alloc;
 
 pub use sp_core::crypto::{key_types, CryptoTypeId, DeriveJunction, KeyTypeId, Ss58Codec};
 #[doc(hidden)]
-pub use sp_core::crypto::{
-	DeriveError, Pair, SecretStringError,
-};
+pub use sp_core::crypto::{DeriveError, Pair, SecretStringError};
 #[doc(hidden)]
 pub use sp_core::{
 	self,
 	crypto::{ByteArray, CryptoType, Derive, IsWrappedBy, Public, Signature, UncheckedFrom, Wraps},
+	pop::{ProofOfPossessionGenerator, ProofOfPossessionVerifier},
 	RuntimeDebug,
-	pop::{ProofOfPossessionGenerator, ProofOfPossessionVerifier, POP_CONTEXT_TAG},
 };
 
 #[doc(hidden)]

--- a/substrate/primitives/application-crypto/src/sr25519.rs
+++ b/substrate/primitives/application-crypto/src/sr25519.rs
@@ -21,7 +21,7 @@ use crate::{KeyTypeId, RuntimePublic};
 
 use alloc::vec::Vec;
 
-use sp_core::pop::POP_CONTEXT_TAG;
+use sp_core::pop::NonAggregatable;
 pub use sp_core::sr25519::*;
 
 mod app {
@@ -50,14 +50,12 @@ impl RuntimePublic for Public {
 	}
 
 	fn generate_pop(&mut self, key_type: KeyTypeId) -> Option<Self::Signature> {
-		let pub_key_as_bytes = self.to_raw_vec();
-		let pop_statement = [POP_CONTEXT_TAG, pub_key_as_bytes.as_slice()].concat();
-		sp_io::crypto::sr25519_sign(key_type, self, pop_statement.as_slice())
+		let pop_statement = Pair::pop_statement(self);
+		sp_io::crypto::sr25519_sign(key_type, self, &pop_statement)
 	}
 
 	fn verify_pop(&self, pop: &Self::Signature) -> bool {
-		let pub_key_as_bytes = self.to_raw_vec();
-		let pop_statement = [POP_CONTEXT_TAG, pub_key_as_bytes.as_slice()].concat();
+		let pop_statement = Pair::pop_statement(self);
 		sp_io::crypto::sr25519_verify(&pop, &pop_statement, &self)
 	}
 


### PR DESCRIPTION
Default method to construct pop statement provided by the `NonAggregatable` trait.

This is less error prone and do not force downstream users to know the internals